### PR TITLE
chore(ci): 🔧 disable caching for .NET SDK setup in CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
-          cache: true
+          cache: false
 
       - name: Restore
         run: dotnet restore


### PR DESCRIPTION
chore(ci): 🔧 disable caching for .NET SDK setup in CI workflow